### PR TITLE
Quilt Server Utils - Inspect me!

### DIFF
--- a/config/yosbr/config/c2me.toml
+++ b/config/yosbr/config/c2me.toml
@@ -1,7 +1,0 @@
-version = 3
-# (Default: 2) Configures the parallelism of global executor.
-globalExecutorParallelism = "2"
-
-[threadedWorldGen]
-	# (Default: false) Whether to enable this feature
-	enabled = false

--- a/config/yosbr/config/c2me.toml
+++ b/config/yosbr/config/c2me.toml
@@ -1,16 +1,6 @@
 version = 3
 # (Default: 2) Configures the parallelism of global executor.
-globalExecutorParallelism = "1"
-
-[clientSideConfig]
-
-	[clientSideConfig.modifyMaxVDConfig]
-		# (Default: true) Whether to modify maximum view distance
-		enabled = false
-
-[noTickViewDistance]
-	# (Default: true) Whether to enable no-tick view distance
-	enabled = false
+globalExecutorParallelism = "2"
 
 [threadedWorldGen]
 	# (Default: false) Whether to enable this feature

--- a/config/yosbr/config/servercore.toml
+++ b/config/yosbr/config/servercore.toml
@@ -1,0 +1,14 @@
+# Lets you enable / disable certain features and modify them.
+[features]
+	# (Default = false) Makes villagers tick less often if they are stuck in a 1x1 space.
+	lobotomize_villagers = true
+	# (Default = 0.5) Decides the radius in blocks that items / xp will merge at.
+	item_merge_radius = 0.75
+	xp_merge_radius = 1.0
+
+# Allows you to toggle specific optimizations that don't have full vanilla parity.
+# These settings will only take effect after server restarts.
+[optimizations]
+	# (Default = false) Can significantly reduce time spent on mobspawning, but isn't as accurate as vanilla on biome borders.
+	# This may cause mobs from another biome to spawn a few blocks across a biome border (this does not affect structure spawning!).
+	fast_biome_lookups = true

--- a/config/yosbr/config/threadtweak.json
+++ b/config/yosbr/config/threadtweak.json
@@ -1,0 +1,8 @@
+{
+  "threadPriority": {
+    "game": 8,
+    "main": 3,
+    "io": 4,
+    "integratedServer": 8
+  }
+}

--- a/config/yosbr/config/vmp.properties
+++ b/config/yosbr/config/vmp.properties
@@ -1,2 +1,3 @@
 # Configuration file for VMP
 show_async_loading_messages=false
+use_multiple_netty_event_loops=false

--- a/index.toml
+++ b/index.toml
@@ -14,7 +14,7 @@ hash = "046d7c779cd4bb987b3dc15102da646a75947869533a1b0356dd543a55ed51c3"
 
 [[files]]
 file = "config/yosbr/config/c2me.toml"
-hash = "cdf61af100d8a29e9bbf26cc1b7ad8ae29c82357831705a97bb1dffa8ab386fa"
+hash = "93beadb849d251357dda6a301d610eeb49e5b04f6d077b5957efcde67ed65438"
 
 [[files]]
 file = "config/yosbr/config/dynamicfps.toml"
@@ -49,6 +49,10 @@ file = "config/yosbr/config/moreculling.toml"
 hash = "7a92a596e22f2bf4a4b64cda5ce614f6d3d9e02d9d2b5c8246173561515d8cc5"
 
 [[files]]
+file = "config/yosbr/config/servercore.toml"
+hash = "4f5cd08148f87464a0f5e471787fd609a6546b653845954598e5a240b938a32d"
+
+[[files]]
 file = "config/yosbr/config/smoothboot.json"
 hash = "c37edec3875da8e561eb60bb7a18dcdce128cc41cfe26261c65a8e942f65d58f"
 
@@ -61,8 +65,12 @@ file = "config/yosbr/config/styled-sidebars/config.json"
 hash = "1862e965057745be91f0cb45fd08d988fe350bfdebfa9ab4e55b6c4272c8be83"
 
 [[files]]
+file = "config/yosbr/config/threadtweak.json"
+hash = "c446a2d6ed316f509a1a51234ecd0468a462c30ced0bacdde428350ef83a9a22"
+
+[[files]]
 file = "config/yosbr/config/vmp.properties"
-hash = "0d0549563aca08c87a22a9fd862cc6e7a9906f2d6fca84dcbfa7cbec14dff7e6"
+hash = "94b8f5236dd7488d6851256816c2edaaaf7224a2be1f7337d554a1eabe475e7f"
 
 [[files]]
 file = "config/yosbr/options.txt"
@@ -76,6 +84,11 @@ metafile = true
 [[files]]
 file = "mods/alloy-forgery.pw.toml"
 hash = "149062fec33cc9b361650d6aacbbb668381007e14ec6b1ef98fb7e4fe9c51685"
+metafile = true
+
+[[files]]
+file = "mods/alternate-current.pw.toml"
+hash = "bedc5fd207a9959c72565f0131b65a8eec71dcdef3e83f6c4556f81e7292326a"
 metafile = true
 
 [[files]]
@@ -104,6 +117,11 @@ hash = "3477ce45c615dbdddf2201bed16d31ee52b7ac5fd12c13631894251313fd649a"
 metafile = true
 
 [[files]]
+file = "mods/async-locator.pw.toml"
+hash = "1c03a3f5b5e061890585ecf6e41995fdc9c9b5081fff50cac3b3e9fd412c63dc"
+metafile = true
+
+[[files]]
 file = "mods/atlas.pw.toml"
 hash = "f2166f09e4d2ee4a43dac512bf31bb5bdb9da121d11ad21940f36446afb4213a"
 metafile = true
@@ -116,6 +134,11 @@ metafile = true
 [[files]]
 file = "mods/azurelib.pw.toml"
 hash = "7d9a59fee9ce605fd38794f8ce8f0c3f42c00ee3e4818281d538920ef98d18d9"
+metafile = true
+
+[[files]]
+file = "mods/banhammer.pw.toml"
+hash = "27b096c8d024c3c935c4c8f099da3516f0a111e61f2e36a995a79b3f9c08dd53"
 metafile = true
 
 [[files]]
@@ -164,6 +187,21 @@ hash = "e3a5e1b9f5c80d1fe052fe9825e3195ffb0fde3a33fe550a832c52e41c3b5452"
 metafile = true
 
 [[files]]
+file = "mods/carpet-extra.pw.toml"
+hash = "5aa266498f131bf7b9d764d608b6416f36555c228110c0d5126bcd7c8bec9f9c"
+metafile = true
+
+[[files]]
+file = "mods/carpet-tis-addition.pw.toml"
+hash = "e024c5bace1bc14b4bf5c370aee991040e7f845a2df1a548dafcbd66588e2442"
+metafile = true
+
+[[files]]
+file = "mods/carpet.pw.toml"
+hash = "8c47daba91f742d52311a9df66bae3296246ecba7ca6f1650579e5739d152d0f"
+metafile = true
+
+[[files]]
 file = "mods/cc-tweaked.pw.toml"
 hash = "2d5625745023a392a509aba9ced8e075990ab07a655c2f330decfa641cdddfcf"
 metafile = true
@@ -179,8 +217,18 @@ hash = "b6348f94ec939f563285dc96683e61da8fc17ab2f2897be2751fa24789513691"
 metafile = true
 
 [[files]]
+file = "mods/clumps.pw.toml"
+hash = "bee4f874bed7a2e61dd5b8a1c41b0d0beb6ffb3d0ef96e12cb0d8df79ed43818"
+metafile = true
+
+[[files]]
 file = "mods/controlify.pw.toml"
 hash = "6f6700ec1170d64907372f36b98abf151bd47809419bcfaf619698fb76a90cd0"
+metafile = true
+
+[[files]]
+file = "mods/convenient-mobgriefing.pw.toml"
+hash = "318590afc60d90c39271890d5f958ffdd06a20f300353b98f064774ff1f9c042"
 metafile = true
 
 [[files]]
@@ -196,6 +244,11 @@ metafile = true
 [[files]]
 file = "mods/demobox.pw.toml"
 hash = "16d1945964bbd4f3c17e3161d8e60bd1e8eb44c4b40c1bb546aaf0ad93304dc4"
+metafile = true
+
+[[files]]
+file = "mods/disableinsecurechattoast.pw.toml"
+hash = "6e9553207ef5219bb0477052b16230369b0a33b2d6d89fe723a4bfbc68b2ee7f"
 metafile = true
 
 [[files]]
@@ -279,6 +332,11 @@ hash = "f3ae608185fe5a7957ade4d1889306f316ae795fcd48e40d1d31362cbf0bf7df"
 metafile = true
 
 [[files]]
+file = "mods/fastback.pw.toml"
+hash = "e4914685936668b58503aa685d970fb929ee5b74dccec730a61747b6857a32b6"
+metafile = true
+
+[[files]]
 file = "mods/fedicraft.pw.toml"
 hash = "07760ba2a154732052b6ea58749566377fe38112b2f190b100e25a60ad0d71ae"
 metafile = true
@@ -359,6 +417,16 @@ hash = "4cd28f6942c4df1618f8a9ccadc41e22666aef02b88315e0424b79c058c404cb"
 metafile = true
 
 [[files]]
+file = "mods/krypton.pw.toml"
+hash = "71ef7cc16632c0039fe194183b5885968c6d740aaa67a58000653ae0cb40b882"
+metafile = true
+
+[[files]]
+file = "mods/ledger.pw.toml"
+hash = "84defc8f8116d5c0e4210934ed1f555641a1db71b767fa4beddee21c47118868"
+metafile = true
+
+[[files]]
 file = "mods/lighty.pw.toml"
 hash = "99f4e1c8ff2abaa03856050029782302cd7ab1307013ede0943b8006312b0c04"
 metafile = true
@@ -374,8 +442,18 @@ hash = "2387c4fefe70d44665f961883f9e2c120ebd9a9f8146767a546fbfdc95623d84"
 metafile = true
 
 [[files]]
+file = "mods/luckperms.pw.toml"
+hash = "239c29cf5b51343fb798e1ba0901c6575f65f4f5fdde2c11f66335b5cec4c08f"
+metafile = true
+
+[[files]]
 file = "mods/luckyducks.pw.toml"
 hash = "dc14f05eb9d64572a0ab21e620eed138cf28c63ca667de18799a4a26f68a207b"
+metafile = true
+
+[[files]]
+file = "mods/maintenancemode.pw.toml"
+hash = "ed2ff97cf59a6c5b9f4e509edbc8c48944bb3c98795f6738c8dfec353cbe350d"
 metafile = true
 
 [[files]]
@@ -426,6 +504,11 @@ metafile = true
 [[files]]
 file = "mods/mythicmetals.pw.toml"
 hash = "3902d0e4b99082a481bdee3dc452f53300c66dcb5b98e710db6f162fa34ba7cd"
+metafile = true
+
+[[files]]
+file = "mods/no-chat-reports.pw.toml"
+hash = "7ca62a9da5c2ec9f0a8bed5394021c959e90077db16b313be44f4c8736f7fbf5"
 metafile = true
 
 [[files]]
@@ -584,6 +667,11 @@ hash = "73b6c3db29f220ca8d258bef24148a31d5bff9e10958bf292d0b0ad1607c5277"
 metafile = true
 
 [[files]]
+file = "mods/restart-server.pw.toml"
+hash = "9c7aed2f43b48129ee2ca30b8840ba656aadd96cf3fb3c9b7f32c6d3ecfd7520"
+metafile = true
+
+[[files]]
 file = "mods/sandwichable.pw.toml"
 hash = "f940a85f7fce47ee3228e10dfde0c7a818d5464337bb8ba0b7074b421975e359"
 metafile = true
@@ -601,6 +689,16 @@ metafile = true
 [[files]]
 file = "mods/scriptor-magicae.pw.toml"
 hash = "9b25ad1b3aee774d33ef858aa7a9daab7338560ba9f2db48480073451cd31bbc"
+metafile = true
+
+[[files]]
+file = "mods/server-controls.pw.toml"
+hash = "3ae5adfbd11f0fa87e516409892bc1151255dfbab72360a086086981add671df"
+metafile = true
+
+[[files]]
+file = "mods/servercore.pw.toml"
+hash = "b5a0689c8ca4d98adb7dfe35df4bc6a1dceac5c4b792e5fbb0ad5290991e2684"
 metafile = true
 
 [[files]]
@@ -634,8 +732,18 @@ hash = "7db1bdb8874134601a2f39ab8907a9ad8a7a606895967eeb095be8839fea929b"
 metafile = true
 
 [[files]]
+file = "mods/spark.pw.toml"
+hash = "7ca0983d3b7852c06f84c66b9f12da8115ff9b8ba63293cd20452377a0de726e"
+metafile = true
+
+[[files]]
 file = "mods/sprite-arrows.pw.toml"
 hash = "9b6c816a530acfd9492ce27d2314dc4a72cc93cf8806854f5abaa6d2db12bce5"
+metafile = true
+
+[[files]]
+file = "mods/starlight.pw.toml"
+hash = "250689d1d6e59b0e76638f28693b3148e72ae66d95c162dfeb7a8f872307f05b"
 metafile = true
 
 [[files]]
@@ -701,6 +809,16 @@ metafile = true
 [[files]]
 file = "mods/threadtweak.pw.toml"
 hash = "bb044cd95d56fb9e1f52a8c18a843df8daf56d22a822568112e9dfa28dab7926"
+metafile = true
+
+[[files]]
+file = "mods/tick-stasis.pw.toml"
+hash = "5a6e4cb2f7907958cc00174a6fae3c8705581d3b0b9fa607d55001e6fcff060d"
+metafile = true
+
+[[files]]
+file = "mods/timeoutout.pw.toml"
+hash = "79bf46f1892bfb23ff9a69b16d0f9147da33809021f0f2ef2f73ae7d10bbefec"
 metafile = true
 
 [[files]]
@@ -794,6 +912,10 @@ hash = "414fc5c2253924a4a03a6613cb7b3cbd06562f23ca1cdffd7fc88597d85b6518"
 metafile = true
 
 [[files]]
+file = "mods/worldedit-mod-7.2.15.jar"
+hash = "17db6b3e94f52d25426684663e1e1846823cbb7907f1c365ac329e5bc7bfaf2c"
+
+[[files]]
 file = "mods/worldedit.pw.toml"
 hash = "bd1dc13316e2aa9b56c89e7e974057f8da8d6bbfe707ba4210109fc612b782e3"
 metafile = true
@@ -816,6 +938,11 @@ metafile = true
 [[files]]
 file = "mods/yardwork.pw.toml"
 hash = "5987fb31fc067a8402d73ee41b3778ef3c4222155e2678637f6e6e8c56f1219b"
+metafile = true
+
+[[files]]
+file = "mods/yawp.pw.toml"
+hash = "80b543298a2387c2a98ebd07971684e2e31b5aed21fbad62b592f6171ccb9622"
 metafile = true
 
 [[files]]

--- a/index.toml
+++ b/index.toml
@@ -13,10 +13,6 @@ file = "config/quilt-loader-overrides.json"
 hash = "046d7c779cd4bb987b3dc15102da646a75947869533a1b0356dd543a55ed51c3"
 
 [[files]]
-file = "config/yosbr/config/c2me.toml"
-hash = "93beadb849d251357dda6a301d610eeb49e5b04f6d077b5957efcde67ed65438"
-
-[[files]]
 file = "config/yosbr/config/dynamicfps.toml"
 hash = "8eac230e722a59915fa26ed453d780cd2034b65ec39a7ffe88135d16840c9692"
 

--- a/mods/alternate-current.pw.toml
+++ b/mods/alternate-current.pw.toml
@@ -1,0 +1,13 @@
+name = "Alternate Current"
+filename = "alternate-current-mc1.20-1.7.0.jar"
+side = "server"
+
+[download]
+url = "https://cdn.modrinth.com/data/r0v8vy1s/versions/zrRsTCOk/alternate-current-mc1.20-1.7.0.jar"
+hash-format = "sha1"
+hash = "4136198cbd1ee00e906f33fc533e10a9324fc2b9"
+
+[update]
+[update.modrinth]
+mod-id = "r0v8vy1s"
+version = "zrRsTCOk"

--- a/mods/async-locator.pw.toml
+++ b/mods/async-locator.pw.toml
@@ -1,0 +1,13 @@
+name = "Async Locator"
+filename = "async-locator-fabric-1.20-1.3.0.jar"
+side = "server"
+
+[download]
+url = "https://cdn.modrinth.com/data/rkN8aqci/versions/xXhZI4u3/async-locator-fabric-1.20-1.3.0.jar"
+hash-format = "sha1"
+hash = "9bd8650056dd2dbbc64c4842f4dc9b9391ee8bf9"
+
+[update]
+[update.modrinth]
+mod-id = "rkN8aqci"
+version = "xXhZI4u3"

--- a/mods/banhammer.pw.toml
+++ b/mods/banhammer.pw.toml
@@ -1,0 +1,13 @@
+name = "BanHammer"
+filename = "banhammer-0.7.0+1.20.jar"
+side = "server"
+
+[download]
+url = "https://cdn.modrinth.com/data/Wpqg0ciI/versions/90JY9flG/banhammer-0.7.0%2B1.20.jar"
+hash-format = "sha1"
+hash = "44822b7e2286134ac530e57cb93fef2d86df0c1b"
+
+[update]
+[update.modrinth]
+mod-id = "Wpqg0ciI"
+version = "90JY9flG"

--- a/mods/carpet-extra.pw.toml
+++ b/mods/carpet-extra.pw.toml
@@ -1,0 +1,13 @@
+name = "Carpet Extra"
+filename = "carpet-extra-1.20-1.4.115.jar"
+side = "server"
+
+[download]
+url = "https://cdn.modrinth.com/data/VX3TgwQh/versions/gPJoJ3mr/carpet-extra-1.20-1.4.115.jar"
+hash-format = "sha1"
+hash = "09f1aeb870393d9ee07d895b5a60c7594a0bddd5"
+
+[update]
+[update.modrinth]
+mod-id = "VX3TgwQh"
+version = "gPJoJ3mr"

--- a/mods/carpet-tis-addition.pw.toml
+++ b/mods/carpet-tis-addition.pw.toml
@@ -1,0 +1,13 @@
+name = "Carpet TIS Addition"
+filename = "carpet-tis-addition-mc1.20.1-v1.49.0.jar"
+side = "server"
+
+[download]
+url = "https://cdn.modrinth.com/data/jE0SjGuf/versions/6zklbAcD/carpet-tis-addition-mc1.20.1-v1.49.0.jar"
+hash-format = "sha1"
+hash = "08514ace00018a10c2d1c8304de2d292da87a1ff"
+
+[update]
+[update.modrinth]
+mod-id = "jE0SjGuf"
+version = "6zklbAcD"

--- a/mods/carpet.pw.toml
+++ b/mods/carpet.pw.toml
@@ -1,0 +1,13 @@
+name = "Carpet"
+filename = "fabric-carpet-1.20-1.4.112+v230608.jar"
+side = "server"
+
+[download]
+url = "https://cdn.modrinth.com/data/TQTTVgYE/versions/K0Wj117C/fabric-carpet-1.20-1.4.112%2Bv230608.jar"
+hash-format = "sha1"
+hash = "29faa4d1c22509b67a6d66b2a8c9d3b5aa483b65"
+
+[update]
+[update.modrinth]
+mod-id = "TQTTVgYE"
+version = "K0Wj117C"

--- a/mods/clumps.pw.toml
+++ b/mods/clumps.pw.toml
@@ -1,0 +1,13 @@
+name = "Clumps"
+filename = "Clumps-fabric-1.20.1-12.0.0.3.jar"
+side = "server"
+
+[download]
+url = "https://cdn.modrinth.com/data/Wnxd13zP/versions/l3neajc5/Clumps-fabric-1.20.1-12.0.0.3.jar"
+hash-format = "sha1"
+hash = "ef8d6b4b83b99153eca38fd1facbb1470cff7ade"
+
+[update]
+[update.modrinth]
+mod-id = "Wnxd13zP"
+version = "l3neajc5"

--- a/mods/convenient-mobgriefing.pw.toml
+++ b/mods/convenient-mobgriefing.pw.toml
@@ -1,0 +1,13 @@
+name = "Convenient mobGriefing"
+filename = "convenient-mobgriefing-2.1.0.jar"
+side = "server"
+
+[download]
+url = "https://cdn.modrinth.com/data/FJI3H6YI/versions/GYP5cKT7/convenient-mobgriefing-2.1.0.jar"
+hash-format = "sha1"
+hash = "bd7bc0b40fda8a145273d9da05641f5a511c0443"
+
+[update]
+[update.modrinth]
+mod-id = "FJI3H6YI"
+version = "GYP5cKT7"

--- a/mods/disableinsecurechattoast.pw.toml
+++ b/mods/disableinsecurechattoast.pw.toml
@@ -1,0 +1,13 @@
+name = "Disable Insecure Chat Toast"
+filename = "DisableInsecureChatToast-mc1.20-1.1.0.jar"
+side = "server"
+
+[download]
+url = "https://cdn.modrinth.com/data/i090SePT/versions/UGKpfpZ6/DisableInsecureChatToast-mc1.20-1.1.0.jar"
+hash-format = "sha1"
+hash = "bbe3e752e2c5ad0c958f24ddad1ff7cd2567448f"
+
+[update]
+[update.modrinth]
+mod-id = "i090SePT"
+version = "UGKpfpZ6"

--- a/mods/fastback.pw.toml
+++ b/mods/fastback.pw.toml
@@ -1,0 +1,13 @@
+name = "Fast Backups"
+filename = "fastback-0.12.0+1.20.1.jar"
+side = "server"
+
+[download]
+url = "https://cdn.modrinth.com/data/ZHKrK8Rp/versions/9NyvBu2u/fastback-0.12.0%2B1.20.1.jar"
+hash-format = "sha1"
+hash = "d42d84a1f70c642a11188fd7a0f7631978b3e722"
+
+[update]
+[update.modrinth]
+mod-id = "ZHKrK8Rp"
+version = "9NyvBu2u"

--- a/mods/krypton.pw.toml
+++ b/mods/krypton.pw.toml
@@ -1,0 +1,13 @@
+name = "Krypton"
+filename = "krypton-0.2.3.jar"
+side = "both"
+
+[download]
+url = "https://cdn.modrinth.com/data/fQEb0iXm/versions/jiDwS0W1/krypton-0.2.3.jar"
+hash-format = "sha1"
+hash = "4d499819effd8afe811e5d93952fcc46765a00df"
+
+[update]
+[update.modrinth]
+mod-id = "fQEb0iXm"
+version = "jiDwS0W1"

--- a/mods/ledger.pw.toml
+++ b/mods/ledger.pw.toml
@@ -1,0 +1,13 @@
+name = "Ledger"
+filename = "ledger-1.2.8.jar"
+side = "server"
+
+[download]
+url = "https://cdn.modrinth.com/data/LVN9ygNV/versions/pOxgWfwI/ledger-1.2.8.jar"
+hash-format = "sha1"
+hash = "6f07421ba3fbe99086f1471c7cc8d8c7fed5dd45"
+
+[update]
+[update.modrinth]
+mod-id = "LVN9ygNV"
+version = "pOxgWfwI"

--- a/mods/luckperms.pw.toml
+++ b/mods/luckperms.pw.toml
@@ -1,0 +1,13 @@
+name = "LuckPerms"
+filename = "LuckPerms-Fabric-5.4.88.jar"
+side = "server"
+
+[download]
+url = "https://cdn.modrinth.com/data/Vebnzrzj/versions/7VG8Evoq/LuckPerms-Fabric-5.4.88.jar"
+hash-format = "sha1"
+hash = "8c9364ad400b9562d1a547ab5cd7f57920adede6"
+
+[update]
+[update.modrinth]
+mod-id = "Vebnzrzj"
+version = "7VG8Evoq"

--- a/mods/maintenancemode.pw.toml
+++ b/mods/maintenancemode.pw.toml
@@ -1,0 +1,13 @@
+name = "Maintenance Mode"
+filename = "mmode-fabric-1.20-1.1.1.jar"
+side = "server"
+
+[download]
+url = "https://cdn.modrinth.com/data/QOkEkSap/versions/TT7eUrpf/mmode-fabric-1.20-1.1.1.jar"
+hash-format = "sha1"
+hash = "da772889aaff617e9d85fd1ff4637663219f38c3"
+
+[update]
+[update.modrinth]
+mod-id = "QOkEkSap"
+version = "TT7eUrpf"

--- a/mods/no-chat-reports.pw.toml
+++ b/mods/no-chat-reports.pw.toml
@@ -1,0 +1,13 @@
+name = "No Chat Reports"
+filename = "NoChatReports-FABRIC-1.20.1-v2.2.2.jar"
+side = "both"
+
+[download]
+url = "https://cdn.modrinth.com/data/qQyHxfxd/versions/HeZZR2kF/NoChatReports-FABRIC-1.20.1-v2.2.2.jar"
+hash-format = "sha1"
+hash = "b99f23fb76aad5a944400717e6d71aa011c4d7f7"
+
+[update]
+[update.modrinth]
+mod-id = "qQyHxfxd"
+version = "HeZZR2kF"

--- a/mods/restart-server.pw.toml
+++ b/mods/restart-server.pw.toml
@@ -1,0 +1,13 @@
+name = "Restart Server"
+filename = "restart-server-1.1.1+mc1.19.x-1.20.x.jar"
+side = "server"
+
+[download]
+url = "https://cdn.modrinth.com/data/zG0Bb7gw/versions/QfZYXGW1/restart-server-1.1.1%2Bmc1.19.x-1.20.x.jar"
+hash-format = "sha1"
+hash = "25485353493f10ac86ec6edb285e83fdbe9137bb"
+
+[update]
+[update.modrinth]
+mod-id = "zG0Bb7gw"
+version = "QfZYXGW1"

--- a/mods/server-controls.pw.toml
+++ b/mods/server-controls.pw.toml
@@ -1,0 +1,13 @@
+name = "Server Controls"
+filename = "servercontrols-1.1.0.jar"
+side = "server"
+
+[download]
+url = "https://cdn.modrinth.com/data/SMaORwAr/versions/KtDDJDdb/servercontrols-1.1.0.jar"
+hash-format = "sha1"
+hash = "46e51443524e14ec6e0911e293d32ea03808f1ea"
+
+[update]
+[update.modrinth]
+mod-id = "SMaORwAr"
+version = "KtDDJDdb"

--- a/mods/servercore.pw.toml
+++ b/mods/servercore.pw.toml
@@ -1,0 +1,13 @@
+name = "ServerCore"
+filename = "servercore-fabric-1.3.7+1.20.1.jar"
+side = "both"
+
+[download]
+url = "https://cdn.modrinth.com/data/4WWQxlQP/versions/exA4UxFq/servercore-fabric-1.3.7%2B1.20.1.jar"
+hash-format = "sha1"
+hash = "fab66f83ded565ba67f6d0f7fecd6861f21409a6"
+
+[update]
+[update.modrinth]
+mod-id = "4WWQxlQP"
+version = "exA4UxFq"

--- a/mods/spark.pw.toml
+++ b/mods/spark.pw.toml
@@ -1,0 +1,13 @@
+name = "spark"
+filename = "spark-1.10.42-fabric.jar"
+side = "both"
+
+[download]
+url = "https://cdn.modrinth.com/data/l6YH9Als/versions/BeIg1bik/spark-1.10.42-fabric.jar"
+hash-format = "sha1"
+hash = "0f0e066808446999f4d63c9db5abf9e3d778a446"
+
+[update]
+[update.modrinth]
+mod-id = "l6YH9Als"
+version = "BeIg1bik"

--- a/mods/starlight.pw.toml
+++ b/mods/starlight.pw.toml
@@ -1,0 +1,13 @@
+name = "Starlight (Fabric)"
+filename = "starlight-1.1.2+fabric.dbc156f.jar"
+side = "server"
+
+[download]
+url = "https://cdn.modrinth.com/data/H8CaAYZC/versions/XGIsoVGT/starlight-1.1.2%2Bfabric.dbc156f.jar"
+hash-format = "sha1"
+hash = "a03102cab439cbab5a1d7d72cd7c2b4976ddd421"
+
+[update]
+[update.modrinth]
+mod-id = "H8CaAYZC"
+version = "XGIsoVGT"

--- a/mods/tick-stasis.pw.toml
+++ b/mods/tick-stasis.pw.toml
@@ -1,0 +1,13 @@
+name = "Tick Stasis"
+filename = "tick-stasis-1.0.0.jar"
+side = "server"
+
+[download]
+url = "https://cdn.modrinth.com/data/t6XBQ2xn/versions/37uhLGmD/tick-stasis-1.0.0.jar"
+hash-format = "sha1"
+hash = "183b424085ef73ad8191656a126ff797622a471f"
+
+[update]
+[update.modrinth]
+mod-id = "t6XBQ2xn"
+version = "37uhLGmD"

--- a/mods/timeoutout.pw.toml
+++ b/mods/timeoutout.pw.toml
@@ -1,0 +1,13 @@
+name = "TimeOutOut"
+filename = "timeoutout-1.0.3+1.19.1.jar"
+side = "server"
+
+[download]
+url = "https://cdn.modrinth.com/data/7cFX55fD/versions/1.0.3/timeoutout-1.0.3%2B1.19.1.jar"
+hash-format = "sha1"
+hash = "ca85e8276c84d67361331ad2aadd5ed1eab3cf8c"
+
+[update]
+[update.modrinth]
+mod-id = "7cFX55fD"
+version = "iDUwwz5Q"

--- a/mods/yawp.pw.toml
+++ b/mods/yawp.pw.toml
@@ -1,0 +1,13 @@
+name = "Yet Another World Protector"
+filename = "yawp-1.20.1-0.0.2.9-beta2-fabric.jar"
+side = "server"
+
+[download]
+url = "https://cdn.modrinth.com/data/py6EMmAJ/versions/O2CYwLDI/yawp-1.20.1-0.0.2.9-beta2-fabric.jar"
+hash-format = "sha1"
+hash = "c888cb37173e5179a45677ef6d6164e9c661b160"
+
+[update]
+[update.modrinth]
+mod-id = "py6EMmAJ"
+version = "O2CYwLDI"

--- a/pack.toml
+++ b/pack.toml
@@ -6,7 +6,7 @@ pack-format = "packwiz:1.1.0"
 [index]
 file = "index.toml"
 hash-format = "sha256"
-hash = "eccc5bc74f7697f2607c38b7b6516770b063ce2d111ffb7b323918cbf78f602c"
+hash = "2c8b0e62bd3a60514da4881dedfca9a13daf5f5dd8d1f2f8a848828a130f7781"
 
 [versions]
 minecraft = "1.20.1"

--- a/pack.toml
+++ b/pack.toml
@@ -6,7 +6,7 @@ pack-format = "packwiz:1.1.0"
 [index]
 file = "index.toml"
 hash-format = "sha256"
-hash = "04070d1093f3cf926147bb91eb1ba5eb76a2f256a2f60fb63c274cbbcf6504bc"
+hash = "eccc5bc74f7697f2607c38b7b6516770b063ce2d111ffb7b323918cbf78f602c"
 
 [versions]
 minecraft = "1.20.1"


### PR DESCRIPTION
Added mods based on quilt server utils - didn't bother to remove client only mods, trusting the environment here. Ths modlist here is based on quilt server utilities, but i kinda ripped out everything that felt like obvious bloat, and I'll leave the utility specifics like carpet/ledger/backups to actual admins.

This can stay as it's own branch and get built to its own spot, or we can merge it into trunk and let the environment selector handle it. up to us!

Removed: invView, antixray, debugify, chunky/border, vanish, easyauth, svc (upstream), essential commands, vanish, autowhitelist/sdl/craterlib, no portals, hey thats mine, memoryleakfix, c2me (didn't that break something?)

Use Me or Lose Me: Fast Backups / Ledger, Carpet/Extra/TIS, YAWP