### PR TITLE
Update PictureSign-Theora

### DIFF
--- a/index.toml
+++ b/index.toml
@@ -1,8 +1,12 @@
 hash-format = "sha256"
 
 [[files]]
+file = "config/betterenchantmentboosting.json"
+hash = "3e02087749a176db651f290ff29bbb6e51fef25579f2f393491524d8c10f2031"
+
+[[files]]
 file = "config/enchancement.json"
-hash = "552967d81e4f24af805d75fcea6e8ae892cfe05296eaf8f5a6c136ab7e58cd1e"
+hash = "43e67af0fe9bf536cfe1d1f3aa99fd3c5998f5474fba5b4e1bc7d8fe4adc3767"
 
 [[files]]
 file = "config/enhanced_bes.properties"
@@ -613,7 +617,7 @@ metafile = true
 
 [[files]]
 file = "mods/picturesign.pw.toml"
-hash = "8492f074a8e446e59da21750b0a97cb9bce059b24faf3733a73898af0d763bea"
+hash = "3fc8c25334d6e343bcafbf516689d29e8795877ebaa11d442176d590726c0024"
 metafile = true
 
 [[files]]

--- a/mods/picturesign.pw.toml
+++ b/mods/picturesign.pw.toml
@@ -1,8 +1,8 @@
 name = "PictureSign"
-filename = "picturesign-2.0.0-beta.1+unascribedtheora.jar"
+filename = "picturesign-2.0.0-beta.1+unascribedtheora2.jar"
 side = "client"
 
 [download]
-url = "https://unascribed.b-cdn.net/picturesign-2.0.0-beta.1%2Bunascribedtheora.jar"
+url = "https://unascribed.b-cdn.net/picturesign-2.0.0-beta.1%2Bunascribedtheora2.jar"
 hash-format = "sha256"
-hash = "e2923fdc1722eacaef14cc4960e634777b93cbaa9edb9d58179fd2e63d9a972d"
+hash = "374c9600fa6066d48dea7e279e62332fccb6f6cacaa1c54b827833ac1921de05"

--- a/pack.toml
+++ b/pack.toml
@@ -6,7 +6,7 @@ pack-format = "packwiz:1.1.0"
 [index]
 file = "index.toml"
 hash-format = "sha256"
-hash = "cc263ced83d5cd644e731152216b7a8242622645e1c588a9c9e081f11d46bcc6"
+hash = "233a8b2e48669bdf105f03b4ddb0664ccbea7dcd4168598cc886bf7e47dc7c99"
 
 [versions]
 minecraft = "1.20.1"


### PR DESCRIPTION
Fixes a memory leak and related lag issue during chunk unloads, which gets worse every frame there's a VideoSign on screen. Caused by an idiosyncracy in the code that was designed for videolib interacting with my weird replacement backend.