### PR TITLE
Mute Arcpocalypse

### DIFF
--- a/config/arcpocalypse.json
+++ b/config/arcpocalypse.json
@@ -1,0 +1,5 @@
+{
+  "burenya": 0,
+  "boomboom": "FULL_SAFE",
+  "lasertime": "FULL_SAFE"
+}

--- a/index.toml
+++ b/index.toml
@@ -1,6 +1,10 @@
 hash-format = "sha256"
 
 [[files]]
+file = "config/arcpocalypse.json"
+hash = "8156a914cba60f5e8284a4298c72c79fb6974082ba584c40510719be0fef1f47"
+
+[[files]]
 file = "config/betterenchantmentboosting.json"
 hash = "3e02087749a176db651f290ff29bbb6e51fef25579f2f393491524d8c10f2031"
 

--- a/pack.toml
+++ b/pack.toml
@@ -6,7 +6,7 @@ pack-format = "packwiz:1.1.0"
 [index]
 file = "index.toml"
 hash-format = "sha256"
-hash = "16770e8d80da3c1ef2e92f90cb706dcf64add420096a5637fb9ac6aa311907b3"
+hash = "5b015b5628428efe49a2ea6e77e9dbdff67b0407d6831bccef089638bab9b7a8"
 
 [versions]
 minecraft = "1.20.1"


### PR DESCRIPTION
The sounds are extremely loud and annoying, and do not honor the obvious "Voice/Speech" option in the Music & Sounds settings. Requiring people to dig into a random mods' settings to stop their ears from bleeding will not fly during the con. The booth can ask people to turn the volume on, or they can honor an easier-to-reach setting, reduce sound frequency, *anything*.

Also copies the FULL_SAFE option for the dangerous powers from the server.