### PR TITLE
Only use advanced tab for Sodium.

### DIFF
--- a/config/sodium-options.json
+++ b/config/sodium-options.json
@@ -1,9 +1,5 @@
 {
   "advanced": {
     "cpu_render_ahead_limit": 4
-  },
-  "performance": {
-    "always_defer_chunk_updates": true,
-    "use_entity_culling": false
   }
 }

--- a/pack.toml
+++ b/pack.toml
@@ -6,7 +6,7 @@ pack-format = "packwiz:1.1.0"
 [index]
 file = "index.toml"
 hash-format = "sha256"
-hash = "4164151e57d3c340be67bada11f4af592f0b63f0a2abe236bdc4537de832ae88"
+hash = "f7c9feef9fd6bd47978e463c88f86d4715ede593b588caff565cf34a932fee0c"
 
 [versions]
 minecraft = "1.20.1"


### PR DESCRIPTION
This removes the entire performance tab that the current Sodium config has for blanketcon which restores entity culling access for it but also undos the "Always defer chunk updates" to be disabled instead as enabling it can destroy performance for certain users except in the v2 version which Sodium 0.5 itself has.