### PR TITLE
Further Bunny-based insulation, fix QSL coming from CurseForge

### DIFF
--- a/bunnify.sh
+++ b/bunnify.sh
@@ -1,12 +1,18 @@
 #!/usr/bin/env bash
 
 # Bunnify
-# Replaces any GitHub links found in the mods folder with a link to the Bunny bucket instead, for stability.
+# Replaces any unreliable links found in the mods folder with a link to the Bunny bucket instead, for stability.
 # Rehashes the pack afterwards.
 
-echo "Converting any stray GitHub links to the Bunny bucket..."
-cd mods
-for f in *.pw.toml; do sed -i 's/github.com/blanketcon.b-cdn.net/g' $f; done
-cd ..
+echo "Converting any stray links to the Bunny bucket..."
+for repl in \
+	'https://github.com/=https://blanketcon.b-cdn.net/' \
+	'https://mvn.devos.one/=https://blanketcon.b-cdn.net/devos/' \
+	'https://ci.blamejared.com/=https://blanketcon.b-cdn.net/jared/' \
+	'https://jaskarth.com/=https://blanketcon.b-cdn.net/jaskarth/' \
+	'https://maven.ithundxr.dev/=https://blanketcon.b-cdn.net/ithundxr/' \
+	; do
+	find -name '*.pw.toml' -print0 | xargs -0 sed -i "s=$repl=g"
+done
 packwiz refresh
 echo "Conversion done!"

--- a/index.toml
+++ b/index.toml
@@ -346,12 +346,12 @@ metafile = true
 
 [[files]]
 file = "mods/create-steam-n-rails.pw.toml"
-hash = "2da07da2b3209b9079214ebfee20e6bf4875e98421c9be066f09ee19657611bd"
+hash = "c0ab997bb28ea28adaf81af96c8e4bf8fc37c63351e26988e16a6db1142cd765"
 metafile = true
 
 [[files]]
 file = "mods/create.pw.toml"
-hash = "2d154fb502a743ac9ea2d9cb1615ad20dddef9851bf8156f424981e9198a1c99"
+hash = "3b3864b79fe83ea11b52410a52ba8ad6402b039491e11152b79e441e502a2f64"
 metafile = true
 
 [[files]]
@@ -426,7 +426,7 @@ metafile = true
 
 [[files]]
 file = "mods/ecotones.pw.toml"
-hash = "f0b6c6404220f25c1965c44814a4a706f27cd711a6bd225a94dcccd6f89fc7bd"
+hash = "1280ee63a56bab220af316658e020236a29b90393c877ab109980b499ca447c5"
 metafile = true
 
 [[files]]
@@ -511,7 +511,7 @@ metafile = true
 
 [[files]]
 file = "mods/fireblanket.pw.toml"
-hash = "54d6da970f0e4ce34d0cd8745c2708e038aeafb596d1070547cf87c579d7ff7b"
+hash = "8ff7176ddb9be7691c1f4016e1102d09dd29fc4d250407c724bf56c8d711e782"
 metafile = true
 
 [[files]]
@@ -521,7 +521,7 @@ metafile = true
 
 [[files]]
 file = "mods/flywheel.pw.toml"
-hash = "c9aac66a7d2f6c91308f1e7e655134a2f2bdf845ebaf09ff834fa91ed7b4e378"
+hash = "bf0031769c52eaac1cd58fbc5454f55ce73e8baccbf74c48a27ba245e2f4f966"
 metafile = true
 
 [[files]]
@@ -651,7 +651,7 @@ metafile = true
 
 [[files]]
 file = "mods/lambdamap.pw.toml"
-hash = "b84e6a37cd67ce05ccf44cfe843022c0a879da545eba00c07aaa6fbcbb1cc8e6"
+hash = "63a3011b3f877eb60972e347a869dc4245382687ef5eb046d7e0f0d34dac00fa"
 metafile = true
 
 [[files]]
@@ -811,7 +811,7 @@ metafile = true
 
 [[files]]
 file = "mods/paucal.pw.toml"
-hash = "2aaf6e577e6fecbef12e10115aea0011e0e7ed732ca4340bb52d3f844d01d465"
+hash = "477f45fde37c4121f4aa107b2d573a99b4ba49625143a814bdd1b76284176ce4"
 metafile = true
 
 [[files]]
@@ -821,7 +821,7 @@ metafile = true
 
 [[files]]
 file = "mods/pehkui.pw.toml"
-hash = "004f94a52a1bc723e624544ae833dfc4c82258d001d749fb588c5e66d9de00cf"
+hash = "780aff4ca1ed8c4d54c798c6d8cec19ceb45efe7f7c89fb3990728729e7b772a"
 metafile = true
 
 [[files]]
@@ -961,7 +961,7 @@ metafile = true
 
 [[files]]
 file = "mods/qsl.pw.toml"
-hash = "63609b108f31e82863487ab43388995e5757818cee60148b053df3b0d3278163"
+hash = "affe1dbede9008f5e03cdf764b4c7a910fe7b9062dbeeb82d99e2497dc8603d8"
 metafile = true
 
 [[files]]
@@ -1036,7 +1036,7 @@ metafile = true
 
 [[files]]
 file = "mods/sodium.pw.toml"
-hash = "f9db4bffd51a3ae0d2f3f9e6cb84c18f658ec12883007a46379fcb83c6af5882"
+hash = "1ed219ddda988f6c1e350aaf003919974cb229dab27e95b166872c55bf6b66ce"
 metafile = true
 
 [[files]]
@@ -1146,7 +1146,7 @@ metafile = true
 
 [[files]]
 file = "mods/terraform-wood-api.pw.toml"
-hash = "014ed1f026199252c3912792e76ac3fc5f0e7633cf4d72b0f82cd42ea6983272"
+hash = "3f0dee0d34913c48c96468b59f61143b061214a87143427b22c5e42d20243a4c"
 metafile = true
 
 [[files]]
@@ -1301,7 +1301,7 @@ metafile = true
 
 [[files]]
 file = "mods/wyd.pw.toml"
-hash = "53f46cfce1ee904eab196edc874147fc651a9d8b57e43aae005aafb0a08f994c"
+hash = "e1cd299fe5f98ace3ca2b1b06955de181e970e4567fab02ff02e13fa392cb2d1"
 metafile = true
 
 [[files]]

--- a/mods/create-steam-n-rails.pw.toml
+++ b/mods/create-steam-n-rails.pw.toml
@@ -2,6 +2,6 @@ name = "create-steam-n-rails"
 filename = "Steam_Rails-fabric-1.20.1-1.5.0+fabric-mc1.20.1-build.544.jar"
 
 [download]
-url = "https://maven.ithundxr.dev/releases/com/railwayteam/railways/Steam_Rails-fabric-1.20.1/1.5.0+fabric-mc1.20.1-build.544/Steam_Rails-fabric-1.20.1-1.5.0+fabric-mc1.20.1-build.544.jar"
+url = "https://blanketcon.b-cdn.net/ithundxr/releases/com/railwayteam/railways/Steam_Rails-fabric-1.20.1/1.5.0+fabric-mc1.20.1-build.544/Steam_Rails-fabric-1.20.1-1.5.0+fabric-mc1.20.1-build.544.jar"
 hash-format = "sha256"
 hash = "ad0ced59925599f97ee626aa71b04993902fa68f78aa1451ead71a875c0ad209"

--- a/mods/create.pw.toml
+++ b/mods/create.pw.toml
@@ -2,6 +2,6 @@ name = "create"
 filename = "create-fabric-1.20.1-0.5.1-d-build.1152+mc1.20.1.jar"
 
 [download]
-url = "https://mvn.devos.one/snapshots/com/simibubi/create/create-fabric-1.20.1/0.5.1-d-build.1152+mc1.20.1/create-fabric-1.20.1-0.5.1-d-build.1152+mc1.20.1.jar"
+url = "https://blanketcon.b-cdn.net/devos/snapshots/com/simibubi/create/create-fabric-1.20.1/0.5.1-d-build.1152+mc1.20.1/create-fabric-1.20.1-0.5.1-d-build.1152+mc1.20.1.jar"
 hash-format = "sha256"
 hash = "4b8329b963ee3aa52a6d0efd21f6129848fa15fa748457e25a650959373c3b71"

--- a/mods/ecotones.pw.toml
+++ b/mods/ecotones.pw.toml
@@ -3,6 +3,6 @@ filename = "ecotones-0.9.4-showcase1.jar"
 side = "both"
 
 [download]
-url = "https://jaskarth.com/pub/mods/ecotones-0.9.4-showcase1.jar"
+url = "https://blanketcon.b-cdn.net/jaskarth/pub/mods/ecotones-0.9.4-showcase1.jar"
 hash-format = "sha256"
 hash = "98426204ef2bb98a29318fd52c528bad312cd500375e17654f1066a38ee3f285"

--- a/mods/fireblanket.pw.toml
+++ b/mods/fireblanket.pw.toml
@@ -2,6 +2,6 @@ name = "fireblanket"
 filename = "fireblanket-0.2.4.jar"
 
 [download]
-url = "https://jaskarth.com/pub/mods/fireblanket-0.2.4.jar"
+url = "https://blanketcon.b-cdn.net/jaskarth/pub/mods/fireblanket-0.2.4.jar"
 hash-format = "sha256"
 hash = "f05d574dd02dd14380df3f4d5a46b143bf5e2a90b2c53b246d47932071a6dfed"

--- a/mods/flywheel.pw.toml
+++ b/mods/flywheel.pw.toml
@@ -2,6 +2,6 @@ name = "flywheel"
 filename = "flywheel-fabric-1.20.1-0.6.9+fenceless.jar"
 
 [download]
-url = "https://jaskarth.com/pub/mods/flywheel-fabric-1.20.1-0.6.9+fenceless.jar"
+url = "https://blanketcon.b-cdn.net/jaskarth/pub/mods/flywheel-fabric-1.20.1-0.6.9+fenceless.jar"
 hash-format = "sha256"
 hash = "9c7c92bf41f05c62c7e0156e85887be68e780b7163c161ce52ee17a113f7c667"

--- a/mods/lambdamap.pw.toml
+++ b/mods/lambdamap.pw.toml
@@ -3,6 +3,6 @@ filename = "lambdamap-1.0.0-alpha.2+1.20.1.jar"
 side = "client"
 
 [download]
-url = "https://github.com/sisby-folk/LambdaMap/releases/download/v1.0.0-alpha.2/lambdamap-1.0.0-alpha.2+1.20.1.jar"
+url = "https://blanketcon.b-cdn.net/sisby-folk/LambdaMap/releases/download/v1.0.0-alpha.2/lambdamap-1.0.0-alpha.2+1.20.1.jar"
 hash-format = "sha1"
 hash = "e29f04351465a39d1de0ef92e3e5a06ac6899d6b"

--- a/mods/paucal.pw.toml
+++ b/mods/paucal.pw.toml
@@ -2,6 +2,6 @@ name = "paucal"
 filename = "paucal-fabric-1.20.1-0.6.0-pre-118.jar"
 
 [download]
-url = "https://ci.blamejared.com/job/petrakat/job/PAUCAL/job/main/lastSuccessfulBuild/artifact/Fabric/build/libs/paucal-fabric-1.20.1-0.6.0-pre-118.jar"
+url = "https://blanketcon.b-cdn.net/jared/job/petrakat/job/PAUCAL/job/main/lastSuccessfulBuild/artifact/Fabric/build/libs/paucal-fabric-1.20.1-0.6.0-pre-118.jar"
 hash-format = "sha256"
 hash = "8b30d6dbca637a0bea8adf58cab1cbe96d4b6083317162381b70305098a12361"

--- a/mods/pehkui.pw.toml
+++ b/mods/pehkui.pw.toml
@@ -2,6 +2,6 @@ name = "pehkui"
 filename = "Pehkui-3.7.8+1.14.4-1.20.1+monitorless.jar"
 
 [download]
-url = "https://jaskarth.com/pub/mods/Pehkui-3.7.8+1.14.4-1.20.1+monitorless.jar"
+url = "https://blanketcon.b-cdn.net/jaskarth/pub/mods/Pehkui-3.7.8+1.14.4-1.20.1+monitorless.jar"
 hash-format = "sha256"
 hash = "8f482918b0391debc603402dbcf78c4f69b38e6eebd286e029d9ed14e7899637"

--- a/mods/qsl.pw.toml
+++ b/mods/qsl.pw.toml
@@ -3,11 +3,11 @@ filename = "qfapi-7.1.1_qsl-6.1.1_fapi-0.86.1_mc-1.20.1.jar"
 side = "both"
 
 [download]
+url = "https://cdn.modrinth.com/data/qvIfYCYJ/versions/ugK6veHN/qfapi-7.1.1_qsl-6.1.1_fapi-0.86.1_mc-1.20.1.jar"
 hash-format = "sha1"
 hash = "6c8117b9f5e502e9dbb2facda1ef4dfcc79f559a"
-mode = "metadata:curseforge"
 
 [update]
-[update.curseforge]
-file-id = 4689070
-project-id = 634179
+[update.modrinth]
+mod-id = "qvIfYCYJ"
+version = "ugK6veHN"

--- a/mods/sodium.pw.toml
+++ b/mods/sodium.pw.toml
@@ -2,6 +2,6 @@ name = "sodium"
 filename = "sodium-fabric-mc1.20-rc1-0.4.10+bc2.jar"
 
 [download]
-url = "https://jaskarth.com/pub/mods/sodium-fabric-mc1.20-rc1-0.4.10+bc2.jar"
+url = "https://blanketcon.b-cdn.net/jaskarth/pub/mods/sodium-fabric-mc1.20-rc1-0.4.10+bc2.jar"
 hash-format = "sha256"
 hash = "a6abf191be840142e181d0f870429066fe8414ff5971f26edb4db912e22e4d12"

--- a/mods/terraform-wood-api.pw.toml
+++ b/mods/terraform-wood-api.pw.toml
@@ -2,6 +2,6 @@ name = "terraform-wood-api"
 filename = "terraform-wood-api-v1-7.0.1+jashacks1.jar"
 
 [download]
-url = "https://jaskarth.com/pub/mods/terraform-wood-api-v1-7.0.1+jashacks1.jar"
+url = "https://blanketcon.b-cdn.net/jaskarth/pub/mods/terraform-wood-api-v1-7.0.1+jashacks1.jar"
 hash-format = "sha256"
 hash = "582e4973131c2a3b518a9a4e6626ca7005937410079b12df58bb8888fec43362"

--- a/mods/wyd.pw.toml
+++ b/mods/wyd.pw.toml
@@ -2,6 +2,6 @@ name = "wyd"
 filename = "wood_you_dye-1.1.0+1.20.1-quilt+jashacks1.jar"
 
 [download]
-url = "https://jaskarth.com/pub/mods/wood_you_dye-1.1.0+1.20.1-quilt+jashacks1.jar"
+url = "https://blanketcon.b-cdn.net/jaskarth/pub/mods/wood_you_dye-1.1.0+1.20.1-quilt+jashacks1.jar"
 hash-format = "sha256"
 hash = "d860f306a08d91de2cd84985f7b70e469964fab8ea06a17ebabf5614a87108a7"

--- a/pack.toml
+++ b/pack.toml
@@ -6,7 +6,7 @@ pack-format = "packwiz:1.1.0"
 [index]
 file = "index.toml"
 hash-format = "sha256"
-hash = "3ea04f15eaf06e283275de88bfe5945f596a189c427ecbdfbac01791c5fcc9d4"
+hash = "a2b49b796fe7d3d709b0c73930b8cf8dd32ed07d4bbd858d2b274fa56ac54ec4"
 
 [versions]
 minecraft = "1.20.1"


### PR DESCRIPTION
Adds various self-hosted sites to bunnify for further insulation and possible protection against spike load downtime — some of these are hosted on suspiciously generous hosting provider free tiers, so let's not take the chance — we already pay for and rely on the CDN.

Also fixes QSL being pulled from Curse for some reason??

Verified this by creating a mrpack export and doing a full unsup rebootstrap for good measure.